### PR TITLE
[DEV-394] removed yamllint and added workflow-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+---
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  check-workflow-version_workflow-ci:
+    uses: vergesense/gha-check-workflow-versions/.github/workflows/check_workflow_versions.yml@v1
+    with:
+      repo-name: 'gha-workflow-ci'
+      reusable-workflow-job-id: workflow-ci
+      gha-workflow-file-name: ci.yml
+  workflow-ci:
+    uses: vergesense/gha-workflow-ci/.github/workflows/workflow_ci.yml@v1

--- a/.github/workflows/terraform_ci.yml
+++ b/.github/workflows/terraform_ci.yml
@@ -38,12 +38,3 @@ jobs:
           echo '1ccd5d719b7aee777908db4d6c142a566e784a3eb0d954900c15db2b8015b2d7  ./tfsec' | sha256sum -c
           chmod 755 ./tfsec
           ./tfsec .
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-      - run: pip install yamllint==1.26.3
-      - run: yamllint .

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,15 @@
+---
+extends: default
+
+rules:
+  comments:
+    level: error
+  comments-indentation:
+    level: error
+  document-start:
+    level: error
+  line-length:
+    max: 125
+  truthy:
+    check-keys: false
+    level: error


### PR DESCRIPTION
Yamllint will be run as part of the `workflow-ci` which will run inside every repo running github actions (so meta).
https://github.com/vergesense/gha-workflow-ci/blob/main/.github/workflows/workflow_ci.yml